### PR TITLE
Add timeseries aggregate charts

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -213,7 +213,7 @@ class App extends React.Component {
           </ButtonToolbar>
         </div>
         <div className="container">
-          <LineGraph data={this.state.data} metricField={this.state.metricField} />
+          {true && <LineGraph data={this.state.data} metricField={this.state.metricField} />}
         </div>
         <div className="container">
           <div className="row m-2">
@@ -221,7 +221,7 @@ class App extends React.Component {
           </div>
           <div className="row">
             {this.state.chartData.filter(chart => !!chart).map((chart, idx) =>
-              (!chart.metricAggregationType || chart.metricAggregationType === AGGREGATION_TYPE_SINGLE) ?
+              chart.metricAggregationType === AGGREGATION_TYPE_SINGLE ?
                 <SingleMetricChart key={`idx-${chart.metricType}-${chart.metricName}-${chart.metricAggregationType}`} type={chart.metricType} metricName={chart.metricName} data={(chart.data || {}).buckets} handleRemovingChart={() => this.handleRemovingChart(idx)} />
                 : <TimeseriesMetricChart key={`idx-${chart.metricType}-${chart.metricName}-${chart.metricAggregationType}`} type={chart.metricType} metricName={chart.metricName} data={(chart.data || {}).buckets} handleRemovingChart={() => this.handleRemovingChart(idx)} />
             )}

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import SingleMetricChart from './single-metric-chart.js';
 import TimeseriesMetricChart from './timeseries-metric-chart.js';
 import DateTimeRangePicker from '@wojtekmaj/react-datetimerange-picker';
 import 'bootstrap/dist/css/bootstrap.min.css';
+import Navbar from 'react-bootstrap/Navbar';
 import Button from 'react-bootstrap/Button';
 import ButtonToolbar from 'react-bootstrap/ButtonToolbar';
 
@@ -187,38 +188,53 @@ class App extends React.Component {
     console.log("### APP RENDER", this.chartTypes);
     return (
       <div className="App">
-        <h1>XHARTS</h1>
+        <Navbar bg="light">
+          <Navbar.Brand href="/">Metrix/Xharts</Navbar.Brand>
+        </Navbar>
+
         <div className="container">
-          <ButtonToolbar>
-            <DateTimeRangePicker
-              onChange={(dates) => this.updateDates.bind(this)(dates)}
-              value={this.state.dates}
-            />
-            <Button
-              style={{
-                borderTopLeftRadius: 0,
-                borderBottomLeftRadius: 0,
-                marginRight: '5px'
-              }}
-              variant="primary"
-              onClick={() => this.submitDates()}
-            >
-              Filter Dates
-            </Button>
-            <MetricFieldTypeahead
-              data={this.state.data}
-              value={this.state.metricField}
-              handleMetricFieldChange={e => this.handleMetricFieldChange(e)}
-            />
-          </ButtonToolbar>
+          <div className="row my-4">
+            <ButtonToolbar>
+              <DateTimeRangePicker
+                onChange={(dates) => this.updateDates.bind(this)(dates)}
+                value={this.state.dates}
+              />
+              <Button
+                style={{
+                  borderTopLeftRadius: 0,
+                  borderBottomLeftRadius: 0,
+                  marginRight: '5px'
+                }}
+                variant="primary"
+                onClick={() => this.submitDates()}
+              >
+                <i class="fa fa-check" aria-hidden="true"></i>
+              </Button>
+              <MetricFieldTypeahead
+                data={this.state.data}
+                value={this.state.metricField}
+                handleMetricFieldChange={e => this.handleMetricFieldChange(e)}
+              />
+            </ButtonToolbar>
+          </div>
         </div>
+
         <div className="container">
+          <div className="row">
+            <h1>At a Glance</h1>
+          </div>
           {true && <LineGraph data={this.state.data} metricField={this.state.metricField} />}
         </div>
+
         <div className="container">
+          <div className="row">
+            <h1>Dashboard</h1>
+          </div>
+
           <div className="row m-2">
             <AddCharts charts={this.state.charts} types={this.chartTypes} metricNames={this.state.metricNames} handleNewChart={(newChart) => this.handleNewChart(newChart)} />
           </div>
+
           <div className="row">
             {this.state.chartData.filter(chart => !!chart).map((chart, idx) =>
               chart.metricAggregationType === AGGREGATION_TYPE_SINGLE ?
@@ -227,6 +243,7 @@ class App extends React.Component {
             )}
           </div>
         </div>
+
         <div style={{height: 150}}></div>
       </div>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -79,6 +79,7 @@ class App extends React.Component {
           new Date(params.start_datetime + "Z" || Date()),
           new Date(params.end_datetime + "Z" || Date())
         ],
+        metricField: params.q || "",
         metricNames
       });
     });
@@ -132,7 +133,7 @@ class App extends React.Component {
     window.history.pushState(
       { startDatetime, endDatetime },
       "XHARTS",
-      `?start_datetime=${startDatetime}&end_datetime=${endDatetime}`
+      `?start_datetime=${startDatetime}&end_datetime=${endDatetime}&q=${this.state.metricField || ""}`
     );
 
     BackendAdapter.getFilteredData({ startDatetime, endDatetime }).then(res => {
@@ -208,7 +209,7 @@ class App extends React.Component {
                 variant="primary"
                 onClick={() => this.submitDates()}
               >
-                <i class="fa fa-check" aria-hidden="true"></i>
+                <i className="fa fa-check" aria-hidden="true"></i>
               </Button>
               <MetricFieldTypeahead
                 data={this.state.data}

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import './App.css';
 import { default as BackendAdapter, dateToQuery } from './backend-adapter.js';
-import AddCharts from './add-charts.js';
+import { default as AddCharts, AGGREGATION_TYPE_SINGLE } from './add-charts.js';
 import { default as MetricFieldTypeahead, getMetricNamesFromData } from './metric-field-typeahead.js';
 import LineGraph from './line-graph.js';
 import SingleMetricChart from './single-metric-chart.js';
@@ -98,6 +98,7 @@ class App extends React.Component {
       const chartDataEntry = {
         metricType: chartParams.metricType,
         metricName: chartParams.metricName,
+        metricAggregationType: chartParams.metricAggregationType,
         data: res.data
       };
 
@@ -146,8 +147,12 @@ class App extends React.Component {
     this.setState({ metricField });
   }
 
-  handleNewChart({ newMetricType, newMetricName }) {
-    const newChart = { metricType: newMetricType, metricName: newMetricName };
+  handleNewChart({ newMetricType, newMetricName, newMetricAggregationType }) {
+    const newChart = {
+      metricType: newMetricType,
+      metricName: newMetricName,
+      metricAggregationType: newMetricAggregationType
+    };
     console.log("adding new Chart", newChart);
     this.setState(prevState => ({
       ...prevState,
@@ -216,9 +221,9 @@ class App extends React.Component {
           </div>
           <div className="row">
             {this.state.chartData.filter(chart => !!chart).map((chart, idx) =>
-              (!chart.bucketCount || chart.bucketCount === 1) ?
-                <SingleMetricChart type={chart.metricType} metricName={chart.metricName} data={(chart.data || {}).buckets} handleRemovingChart={() => this.handleRemovingChart(idx)} />
-                : <TimeseriesMetricChart type={chart.metricType} metricName={chart.metricName} data={(chart.data || {}).buckets} handleRemovingChart={() => this.handleRemovingChart(idx)} />
+              (!chart.metricAggregationType || chart.metricAggregationType === AGGREGATION_TYPE_SINGLE) ?
+                <SingleMetricChart key={`idx-${chart.metricType}-${chart.metricName}-${chart.metricAggregationType}`} type={chart.metricType} metricName={chart.metricName} data={(chart.data || {}).buckets} handleRemovingChart={() => this.handleRemovingChart(idx)} />
+                : <TimeseriesMetricChart key={`idx-${chart.metricType}-${chart.metricName}-${chart.metricAggregationType}`} type={chart.metricType} metricName={chart.metricName} data={(chart.data || {}).buckets} handleRemovingChart={() => this.handleRemovingChart(idx)} />
             )}
           </div>
         </div>

--- a/src/App.js
+++ b/src/App.js
@@ -75,8 +75,8 @@ class App extends React.Component {
         data: res.data,
         isLoading: false,
         dates: [
-          new Date(params.start_datetime || Date()),
-          new Date(params.end_datetime || Date())
+          new Date(params.start_datetime + "Z" || Date()),
+          new Date(params.end_datetime + "Z" || Date())
         ],
         metricNames
       });

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import AddCharts from './add-charts.js';
 import { default as MetricFieldTypeahead, getMetricNamesFromData } from './metric-field-typeahead.js';
 import LineGraph from './line-graph.js';
 import SingleMetricChart from './single-metric-chart.js';
+import TimeseriesMetricChart from './timeseries-metric-chart.js';
 import DateTimeRangePicker from '@wojtekmaj/react-datetimerange-picker';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import Button from 'react-bootstrap/Button';
@@ -215,7 +216,9 @@ class App extends React.Component {
           </div>
           <div className="row">
             {this.state.chartData.filter(chart => !!chart).map((chart, idx) =>
-              <SingleMetricChart type={chart.metricType} metricName={chart.metricName} data={(chart.data || {}).buckets} handleRemovingChart={() => this.handleRemovingChart(idx)} />
+              (!chart.bucketCount || chart.bucketCount === 1) ?
+                <SingleMetricChart type={chart.metricType} metricName={chart.metricName} data={(chart.data || {}).buckets} handleRemovingChart={() => this.handleRemovingChart(idx)} />
+                : <TimeseriesMetricChart type={chart.metricType} metricName={chart.metricName} data={(chart.data || {}).buckets} handleRemovingChart={() => this.handleRemovingChart(idx)} />
             )}
           </div>
         </div>

--- a/src/App.js
+++ b/src/App.js
@@ -53,7 +53,6 @@ class App extends React.Component {
   }
 
   getQueryParams() {
-    console.log("query params", window.location.search);
     let params = this.parseQueryParams(window.location.search.slice(1));
     params.startDatetime = params.start_datetime;
     params.endDatetime = params.end_datetime;
@@ -61,15 +60,15 @@ class App extends React.Component {
   }
 
   componentDidMount() {
-    console.log("Loading Metrics START");
+    this.refreshAll();
+  }
 
+  refreshAll() {
     const params = this.getQueryParams();
 
-    console.log("query params", params);
+    console.log("refreshAll w/ query params:", params);
 
     BackendAdapter.getFilteredData(params).then(res => {
-      console.log("Loading Metrics DONE", res.data);
-
       let metricNames = getMetricNamesFromData(res.data);
 
       this.setState({
@@ -131,18 +130,19 @@ class App extends React.Component {
 
     // the pushedState isn't utilized by the app yet...but it _could_ be
     window.history.pushState(
-      { startDatetime, endDatetime },
+      { startDatetime, endDatetime, q: this.state.metricField },
       "XHARTS",
-      `?start_datetime=${startDatetime}&end_datetime=${endDatetime}&q=${this.state.metricField || ""}`
+      `?start_datetime=${startDatetime}&end_datetime=${endDatetime}${this.state.metricField ? "&q=" + this.state.metricField : ""}`
     );
 
-    BackendAdapter.getFilteredData({ startDatetime, endDatetime }).then(res => {
-      console.log("Filtering done", res.data);
+    // BackendAdapter.getFilteredData({ startDatetime, endDatetime }).then(res => {
+    //   console.log("Filtering done", res.data);
 
-      let metricNames = getMetricNamesFromData(res.data);
+    //   let metricNames = getMetricNamesFromData(res.data);
 
-      this.setState({ data: res.data, metricNames });
-    });
+    //   this.setState({ data: res.data, metricNames });
+    // });
+    this.refreshAll();
   }
 
   handleMetricFieldChange(metricField) {
@@ -166,7 +166,6 @@ class App extends React.Component {
     charts.push(newChart);
     window.localStorage.setItem("charts", JSON.stringify(charts));
 
-    // async load chart data
     this.refreshChartAtIdx({ idx: charts.length - 1, chartParams: newChart });
   }
 
@@ -186,7 +185,6 @@ class App extends React.Component {
   }
 
   render() {
-    console.log("### APP RENDER", this.chartTypes);
     return (
       <div className="App">
         <Navbar bg="light">

--- a/src/App.js
+++ b/src/App.js
@@ -81,7 +81,7 @@ class App extends React.Component {
       });
     });
 
-    this.state.charts.map((chartParams, idx) => {
+    this.state.charts.forEach((chartParams, idx) => {
       this.refreshChartAtIdx({ idx, chartParams }, params);
     });
   }

--- a/src/add-charts.js
+++ b/src/add-charts.js
@@ -39,20 +39,6 @@ class AddCharts extends React.Component {
       newMetricName: this.state.newMetricName,
       newMetricAggregationType: this.state.newMetricAggregationType
     });
-
-    this.clearInputFields();
-  }
-
-  // THIS IS A HACK BECAUSE THE TYPEAHEAD LIBRARY DOES NOT EXPOSE A
-  // PROGRAMATIC WAY TO CLEAR THE STUPID INPUT FIELDS
-  clearInputFields = () => {
-    setTimeout(() => {
-      const typeBtn = document.querySelector(".metric-type .close");
-      typeBtn.click();
-
-      const nameBtn = document.querySelector(".metric-name .close");
-      nameBtn.click();
-    });
   }
 
   render() {
@@ -66,6 +52,7 @@ class AddCharts extends React.Component {
             onChange={value =>
               this.setState({ newMetricType: value[0] })
             }
+            selected={[this.state.newMetricType || ""]}
             options={getMetricTypeOptions(this.props.types)}
           />
           <div style={{width: "5px"}}></div>
@@ -76,6 +63,7 @@ class AddCharts extends React.Component {
             onChange={value =>
               this.setState({ newMetricName: value[0] })
             }
+            selected={[this.state.newMetricName || ""]}
             options={getMetricOptions(this.props.metricNames)}
           />
           <div style={{width: "5px"}}></div>

--- a/src/add-charts.js
+++ b/src/add-charts.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
 import { Typeahead } from 'react-bootstrap-typeahead';
 import 'react-bootstrap-typeahead/css/Typeahead.css';
-import InputGroup from 'react-bootstrap/InputGroup';
-import Button from 'react-bootstrap/Button';
 
-const getTypeOptions = (types) => {
+const getMetricTypeOptions = (types) => {
   return types.map((label, id) => ({ id, label }));
 }
 
@@ -12,21 +13,31 @@ const getMetricOptions = (data) => {
   return data.map((label, id) => ({ id, label }));
 }
 
+const AGGREGATION_TYPE_SINGLE = "single";
+const AGGREGATION_TYPE_TIMESERIES = "timeseries";
+const AGGREGATION_TYPES = [
+  AGGREGATION_TYPE_SINGLE,
+  AGGREGATION_TYPE_TIMESERIES
+];
+
 class AddCharts extends React.Component {
 
   state = {
     newMetricType: "",
-    newMetricName: ""
+    newMetricName: "",
+    newMetricAggregationType: AGGREGATION_TYPES[0]
   }
 
   handleNewChart = () => {
     console.log({
       newMetricType: this.state.newMetricType.label,
-      newMetricName: this.state.newMetricName.label
+      newMetricName: this.state.newMetricName.label,
+      newMetricAggregationType: this.state.newMetricAggregationType
     });
     this.props.handleNewChart({
       newMetricType: this.state.newMetricType.label,
-      newMetricName: this.state.newMetricName.label
+      newMetricName: this.state.newMetricName.label,
+      newMetricAggregationType: this.state.newMetricAggregationType
     });
 
     this.clearInputFields();
@@ -48,16 +59,15 @@ class AddCharts extends React.Component {
     return (
       <div>
         <InputGroup>
-          <InputGroup.Prepend>
-            <Typeahead
-              className="metric-type"
-              clearButton
-              onChange={value =>
-                this.setState({ newMetricType: value[0] })
-              }
-              options={console.log(this.props) || getTypeOptions(this.props.types)}
-            />
-          </InputGroup.Prepend>
+          <Typeahead
+            className="metric-type"
+            clearButton
+            onChange={value =>
+              this.setState({ newMetricType: value[0] })
+            }
+            options={getMetricTypeOptions(this.props.types)}
+          />
+          <div style={{width: "5px"}}></div>
           <Typeahead
             className="metric-name"
             clearButton
@@ -66,15 +76,19 @@ class AddCharts extends React.Component {
             }
             options={getMetricOptions(this.props.metricNames)}
           />
-          <InputGroup.Append>
-            <Button
-              variant="primary"
-              disabled={!this.state.newMetricType || !this.state.newMetricName}
-              onClick={() => this.handleNewChart()}
-            >
-              Add Metric
-            </Button>
-          </InputGroup.Append>
+          <div style={{width: "5px"}}></div>
+          <Form.Control as="select" onChange={(e) => this.setState({ newMetricAggregationType: e.target.value })}>
+            {AGGREGATION_TYPES.map(selection => <option key={selection}>{selection}</option>)}
+          </Form.Control>
+          <div style={{width: "5px"}}></div>
+          <Button
+            variant="primary"
+            disabled={!this.state.newMetricType || !this.state.newMetricName}
+            onClick={() => this.handleNewChart()}
+          >
+            <i className="fa fa-plus" aria-hidden="true"></i>
+          </Button>
+
         </InputGroup>
       </div>
     );
@@ -82,3 +96,9 @@ class AddCharts extends React.Component {
 }
 
 export default AddCharts;
+
+export {
+  AGGREGATION_TYPE_SINGLE,
+  AGGREGATION_TYPE_TIMESERIES,
+  AGGREGATION_TYPES
+};

--- a/src/add-charts.js
+++ b/src/add-charts.js
@@ -6,11 +6,11 @@ import { Typeahead } from 'react-bootstrap-typeahead';
 import 'react-bootstrap-typeahead/css/Typeahead.css';
 
 const getMetricTypeOptions = (types) => {
-  return types.map((label, id) => ({ id, label }));
+  return types;
 }
 
 const getMetricOptions = (data) => {
-  return data.map((label, id) => ({ id, label }));
+  return data;
 }
 
 const AGGREGATION_TYPE_SINGLE = "single";
@@ -30,13 +30,13 @@ class AddCharts extends React.Component {
 
   handleNewChart = () => {
     console.log({
-      newMetricType: this.state.newMetricType.label,
-      newMetricName: this.state.newMetricName.label,
+      newMetricType: this.state.newMetricType,
+      newMetricName: this.state.newMetricName,
       newMetricAggregationType: this.state.newMetricAggregationType
     });
     this.props.handleNewChart({
-      newMetricType: this.state.newMetricType.label,
-      newMetricName: this.state.newMetricName.label,
+      newMetricType: this.state.newMetricType,
+      newMetricName: this.state.newMetricName,
       newMetricAggregationType: this.state.newMetricAggregationType
     });
 
@@ -60,6 +60,7 @@ class AddCharts extends React.Component {
       <div>
         <InputGroup>
           <Typeahead
+            id="metric-type-typeahead"
             className="metric-type"
             clearButton
             onChange={value =>
@@ -69,6 +70,7 @@ class AddCharts extends React.Component {
           />
           <div style={{width: "5px"}}></div>
           <Typeahead
+            id="metric-name-typeahead"
             className="metric-name"
             clearButton
             onChange={value =>

--- a/src/backend-adapter.js
+++ b/src/backend-adapter.js
@@ -1,3 +1,5 @@
+import { AGGREGATION_TYPE_SINGLE, AGGREGATION_TYPE_TIMESERIES } from './add-charts.js';
+
 const dummyData = {
   data: [
     {
@@ -256,7 +258,7 @@ class BackendAdapter {
   }
 
   query(filters) {
-    const { startDatetime, endDatetime, metricName, metricType } = filters;
+    const { startDatetime, endDatetime, metricName, metricType, metricAggregationType } = filters;
     let url = `/metrics/${metricType}?`;
 
     let params = new URLSearchParams();
@@ -264,7 +266,7 @@ class BackendAdapter {
     params.set('start_datetime', startDatetime);
     params.set('end_datetime', endDatetime);
     params.set('metric_name', metricName);
-    params.set('bucket_count', 1);
+    params.set('bucket_count', metricAggregationType !== AGGREGATION_TYPE_TIMESERIES ? 1 : 25);
 
     url += "&" + params.toString();
 

--- a/src/backend-adapter.js
+++ b/src/backend-adapter.js
@@ -311,10 +311,11 @@ class BackendAdapter {
     params.set('metric_name', metricName);
     params.set('bucket_count', metricAggregationType !== AGGREGATION_TYPE_TIMESERIES ? 1 : 10);
 
-    url += "&" + params.toString();
+    url += params.toString();
 
     return fetch(url)
-      .then(res => res.json());
+      .then(res => res.json())
+      .then(res => console.log("response", res) || res);
   }
 
   queryCount(filters) {

--- a/src/backend-adapter.js
+++ b/src/backend-adapter.js
@@ -219,6 +219,49 @@ const dummyData = {
   }
 };
 
+const manyBuckets = () => [
+  {
+    "value": 0,
+    "bucket": "2019-12-24T17:38:00"
+  },
+  {
+    "value": 1,
+    "bucket": "2019-12-24T17:38:24"
+  },
+  {
+    "value": 0,
+    "bucket": "2019-12-24T17:38:48"
+  },
+  {
+    "value": 1,
+    "bucket": "2019-12-24T17:39:12"
+  },
+  {
+    "value": 1,
+    "bucket": "2019-12-24T17:39:36"
+  },
+  {
+    "value": 0,
+    "bucket": "2019-12-24T17:40:00"
+  },
+  {
+    "value": 1,
+    "bucket": "2019-12-24T17:40:24"
+  },
+  {
+    "value": 2,
+    "bucket": "2019-12-24T17:40:48"
+  },
+  {
+    "value": 1,
+    "bucket": "2019-12-24T17:41:12"
+  },
+  {
+    "value": 3,
+    "bucket": "2019-12-24T17:41:36"
+  }
+];
+
 const dateToQuery = (date) => date.toISOString().slice(0, -5);
 
 class BackendAdapter {
@@ -266,7 +309,7 @@ class BackendAdapter {
     params.set('start_datetime', startDatetime);
     params.set('end_datetime', endDatetime);
     params.set('metric_name', metricName);
-    params.set('bucket_count', metricAggregationType !== AGGREGATION_TYPE_TIMESERIES ? 1 : 25);
+    params.set('bucket_count', metricAggregationType !== AGGREGATION_TYPE_TIMESERIES ? 1 : 10);
 
     url += "&" + params.toString();
 
@@ -278,10 +321,10 @@ class BackendAdapter {
     if (filters.mock) {
       return Promise.resolve({
         data: {
-          buckets: [{
+          buckets: filters.metricAggregationType === AGGREGATION_TYPE_SINGLE ? [{
             value: Math.floor(Math.random() * 100),
             bucket: "random bucket name"
-          }]
+          }] : manyBuckets()
         }
       });
     }

--- a/src/line-graph.js
+++ b/src/line-graph.js
@@ -15,9 +15,7 @@ function formatMetrics(metrics, metricField) {
     });
   });
 
-  const results = Object.keys(formatted).map(metric_name => formatted[metric_name]);
-  console.log(results);
-  return results;
+  return Object.keys(formatted).map(metric_name => formatted[metric_name]);
 }
 
 const METRIC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f";

--- a/src/metric-field-typeahead.js
+++ b/src/metric-field-typeahead.js
@@ -17,12 +17,11 @@ function getKeysFromObj(obj) {
 
 function getOptionsFromData(data) {
   const options = new Set();
-  console.log("getOptionsFromData", data);
+
   data.forEach(metric => {
     getKeysFromObj(metric.data).forEach(k => options.add(k));
   });
 
-  console.log("metric-field-typeahead options", Array.from(options));
   return Array.from(options);
 }
 

--- a/src/metric-field-typeahead.js
+++ b/src/metric-field-typeahead.js
@@ -31,7 +31,7 @@ class MetricFieldTypeahead extends React.PureComponent {
     return (
       <InputGroup>
         <InputGroup.Prepend>
-          <InputGroup.Text id="basic-addon1">Metric Fieldname</InputGroup.Text>
+          <InputGroup.Text id="basic-addon1">Metric name</InputGroup.Text>
         </InputGroup.Prepend>
         <Typeahead
           id="main-chart-metric-field-typeahead"

--- a/src/metric-field-typeahead.js
+++ b/src/metric-field-typeahead.js
@@ -38,6 +38,8 @@ class MetricFieldTypeahead extends React.PureComponent {
           onChange={value =>
             this.props.handleMetricFieldChange(value[0])
           }
+          clearButton
+          selected={[this.props.value || ""]}
           options={getOptionsFromData(this.props.data)}
         />
       </InputGroup>

--- a/src/metric-field-typeahead.js
+++ b/src/metric-field-typeahead.js
@@ -22,7 +22,7 @@ function getOptionsFromData(data) {
     getKeysFromObj(metric.data).forEach(k => options.add(k));
   });
 
-  console.log(Array.from(options));
+  console.log("metric-field-typeahead options", Array.from(options));
   return Array.from(options);
 }
 
@@ -34,6 +34,7 @@ class MetricFieldTypeahead extends React.PureComponent {
           <InputGroup.Text id="basic-addon1">Metric Fieldname</InputGroup.Text>
         </InputGroup.Prepend>
         <Typeahead
+          id="main-chart-metric-field-typeahead"
           onChange={value =>
             this.props.handleMetricFieldChange(value[0])
           }

--- a/src/single-metric-chart.js
+++ b/src/single-metric-chart.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default ({ type, metricName, data, handleRemovingChart }) => {
   return (
-    <div className="col-md-4 mb-4">
+    <div className="col-md-6 mb-4">
       <div className="card">
         <span
           style={{textAlign: "right", cursor: "pointer"}}
@@ -15,7 +15,7 @@ export default ({ type, metricName, data, handleRemovingChart }) => {
           <h1>{data && data.length === 1 ? data[0].value : "Loading..."}</h1>
           <small>
             <strong>{type}</strong>
-            {" chart for "}
+            {" card for "}
             <strong>{metricName}</strong>
           </small>
         </div>

--- a/src/timeseries-metric-chart.js
+++ b/src/timeseries-metric-chart.js
@@ -56,16 +56,13 @@ const MyResponsiveLine = ({ data, yAxisLabel, xFormatter }) => (
   />
 );
 
-const prepareData = (ndata) => {
-  const processed = ndata.map(datum => ({
+const prepareData = (rawData) => {
+  return rawData.map(datum => ({
     ...datum,
     data: datum.data.map(bucket =>
       ({ x: bucket.bucket, y: bucket.value })
     )
   }));
-
-  console.log("prepareData", processed);
-  return processed;
 };
 
 const graphWrapper = (data) => {

--- a/src/timeseries-metric-chart.js
+++ b/src/timeseries-metric-chart.js
@@ -30,7 +30,7 @@ const MyResponsiveLine = ({ data, yAxisLabel, xFormatter }) => (
       tickSize: 5,
       tickPadding: 5,
       tickRotation: 270,
-      legend: 'Time/Bucket',
+      legend: 'time/bucket',
       legendOffset: 26,
       legendPosition: 'middle'
     }}
@@ -51,6 +51,8 @@ const MyResponsiveLine = ({ data, yAxisLabel, xFormatter }) => (
     pointLabel="y"
     pointLabelYOffset={-12}
     useMesh={true}
+    enableGridX={false}
+    // enableGridY={false}
   />
 );
 
@@ -73,15 +75,19 @@ const graphWrapper = (data) => {
   if (lastIdx === false) lastIdx = data.data[0].bucket.length - 6;
 
   return (
-    <div style={{minHeight: "300px", height: "300px"}}>
-      <MyResponsiveLine data={prepareData([data])} yAxisLabel={`${data.type} for ${data.id}`} xFormatter={(val) => val.slice(lastIdx)} />
+    <div style={{minHeight: "150px", height: "150px"}}>
+      <MyResponsiveLine
+        data={prepareData([data])}
+        yAxisLabel={`${data.type} for ${data.id}`}
+        xFormatter={(val) => val.slice(lastIdx)}
+      />
     </div>
   );
 };
 
 export default ({ type, metricName, data, handleRemovingChart }) => {
   return (
-    <div className="col-md-4 mb-4">
+    <div className="col-md-6 mb-4">
       <div className="card">
         <span
           style={{textAlign: "right", cursor: "pointer"}}

--- a/src/timeseries-metric-chart.js
+++ b/src/timeseries-metric-chart.js
@@ -9,7 +9,7 @@ function firstIndexOfDisimilarity(str1, str2) {
     idx++;
   }
 
-  if (idx == Math.min(str1.length, str2.length)) {
+  if (idx === Math.min(str1.length, str2.length)) {
     return false;
   }
 

--- a/src/timeseries-metric-chart.js
+++ b/src/timeseries-metric-chart.js
@@ -12,7 +12,7 @@ export default ({ type, metricName, data, handleRemovingChart }) => {
           <i className="fa fa-times" aria-hidden="true"></i>
         </span>
         <div className="card-body">
-          <h1>{!!data ? "THIS IS TIME SERIES DATA" : "Loading Timeseries..."}</h1>
+          <h1>{!!data ? "THIS IS TIME SERIES DATA: " + JSON.stringify(data) : "Loading Timeseries..."}</h1>
           <small>
             <strong>{type}</strong>
             {" chart for "}

--- a/src/timeseries-metric-chart.js
+++ b/src/timeseries-metric-chart.js
@@ -1,4 +1,361 @@
 import React from 'react';
+import { ResponsiveLine } from '@nivo/line'
+
+const METRIC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f";
+const TIME_DISPLAY_FORMAT = "%H:%M:%S";
+
+const data = [
+    {
+      "id": "japan",
+      "color": "hsl(112, 70%, 50%)",
+      "data": [
+        {
+          "x": "plane",
+          "y": 49
+        },
+        {
+          "x": "helicopter",
+          "y": 252
+        },
+        {
+          "x": "boat",
+          "y": 244
+        },
+        {
+          "x": "train",
+          "y": 231
+        },
+        {
+          "x": "subway",
+          "y": 243
+        },
+        {
+          "x": "bus",
+          "y": 151
+        },
+        {
+          "x": "car",
+          "y": 112
+        },
+        {
+          "x": "moto",
+          "y": 264
+        },
+        {
+          "x": "bicycle",
+          "y": 170
+        },
+        {
+          "x": "horse",
+          "y": 99
+        },
+        {
+          "x": "skateboard",
+          "y": 299
+        },
+        {
+          "x": "others",
+          "y": 219
+        }
+      ]
+    },
+    {
+      "id": "france",
+      "color": "hsl(145, 70%, 50%)",
+      "data": [
+        {
+          "x": "plane",
+          "y": 86
+        },
+        {
+          "x": "helicopter",
+          "y": 171
+        },
+        {
+          "x": "boat",
+          "y": 29
+        },
+        {
+          "x": "train",
+          "y": 171
+        },
+        {
+          "x": "subway",
+          "y": 37
+        },
+        {
+          "x": "bus",
+          "y": 256
+        },
+        {
+          "x": "car",
+          "y": 3
+        },
+        {
+          "x": "moto",
+          "y": 295
+        },
+        {
+          "x": "bicycle",
+          "y": 252
+        },
+        {
+          "x": "horse",
+          "y": 235
+        },
+        {
+          "x": "skateboard",
+          "y": 256
+        },
+        {
+          "x": "others",
+          "y": 69
+        }
+      ]
+    },
+    {
+      "id": "us",
+      "color": "hsl(345, 70%, 50%)",
+      "data": [
+        {
+          "x": "plane",
+          "y": 225
+        },
+        {
+          "x": "helicopter",
+          "y": 23
+        },
+        {
+          "x": "boat",
+          "y": 0
+        },
+        {
+          "x": "train",
+          "y": 216
+        },
+        {
+          "x": "subway",
+          "y": 186
+        },
+        {
+          "x": "bus",
+          "y": 104
+        },
+        {
+          "x": "car",
+          "y": 145
+        },
+        {
+          "x": "moto",
+          "y": 282
+        },
+        {
+          "x": "bicycle",
+          "y": 272
+        },
+        {
+          "x": "horse",
+          "y": 95
+        },
+        {
+          "x": "skateboard",
+          "y": 101
+        },
+        {
+          "x": "others",
+          "y": 67
+        }
+      ]
+    },
+    {
+      "id": "germany",
+      "color": "hsl(293, 70%, 50%)",
+      "data": [
+        {
+          "x": "plane",
+          "y": 245
+        },
+        {
+          "x": "helicopter",
+          "y": 251
+        },
+        {
+          "x": "boat",
+          "y": 55
+        },
+        {
+          "x": "train",
+          "y": 118
+        },
+        {
+          "x": "subway",
+          "y": 23
+        },
+        {
+          "x": "bus",
+          "y": 167
+        },
+        {
+          "x": "car",
+          "y": 47
+        },
+        {
+          "x": "moto",
+          "y": 23
+        },
+        {
+          "x": "bicycle",
+          "y": 118
+        },
+        {
+          "x": "horse",
+          "y": 50
+        },
+        {
+          "x": "skateboard",
+          "y": 100
+        },
+        {
+          "x": "others",
+          "y": 131
+        }
+      ]
+    },
+    {
+      "id": "norway",
+      "color": "hsl(72, 70%, 50%)",
+      "data": [
+        {
+          "x": "plane",
+          "y": 280
+        },
+        {
+          "x": "helicopter",
+          "y": 50
+        },
+        {
+          "x": "boat",
+          "y": 48
+        },
+        {
+          "x": "train",
+          "y": 207
+        },
+        {
+          "x": "subway",
+          "y": 200
+        },
+        {
+          "x": "bus",
+          "y": 209
+        },
+        {
+          "x": "car",
+          "y": 284
+        },
+        {
+          "x": "moto",
+          "y": 218
+        },
+        {
+          "x": "bicycle",
+          "y": 32
+        },
+        {
+          "x": "horse",
+          "y": 260
+        },
+        {
+          "x": "skateboard",
+          "y": 276
+        },
+        {
+          "x": "others",
+          "y": 298
+        }
+      ]
+    }
+  ];
+
+const MyResponsiveLine = ({ data, yAxisLabel }) => (
+  <ResponsiveLine
+    data={data}
+    margin={{ top: 50, right: 110, bottom: 50, left: 60 }}
+    xScale={{ type: 'point' }}
+    yScale={{ type: 'linear', stacked: true, min: 'auto', max: 'auto' }}
+    axisTop={null}
+    axisRight={null}
+    axisBottom={{
+      orient: 'bottom',
+      tickSize: 5,
+      tickPadding: 5,
+      tickRotation: 0,
+      legend: 'Time/Bucket',
+      legendOffset: 36,
+      legendPosition: 'middle'
+    }}
+    axisLeft={{
+      orient: 'left',
+      tickSize: 5,
+      tickPadding: 5,
+      tickRotation: 0,
+      legend: yAxisLabel,
+      legendOffset: -40,
+      legendPosition: 'middle'
+    }}
+    colors={{ scheme: 'nivo' }}
+    pointSize={10}
+    pointColor={{ theme: 'background' }}
+    pointBorderWidth={2}
+    pointBorderColor={{ from: 'serieColor' }}
+    pointLabel="y"
+    pointLabelYOffset={-12}
+    useMesh={true}
+    _legends={[
+      {
+        anchor: 'bottom-right',
+        direction: 'column',
+        justify: false,
+        translateX: 100,
+        translateY: 0,
+        itemsSpacing: 0,
+        itemDirection: 'left-to-right',
+        itemWidth: 80,
+        itemHeight: 20,
+        itemOpacity: 0.75,
+        symbolSize: 12,
+        symbolShape: 'circle',
+        symbolBorderColor: 'rgba(0, 0, 0, .5)',
+        effects: [
+          {
+            on: 'hover',
+            style: {
+              itemBackground: 'rgba(0, 0, 0, .03)',
+              itemOpacity: 1
+            }
+          }
+        ]
+      }
+    ]}
+  />
+);
+
+const prepareData = (ndata) => {
+  const processed = ndata.map(datum => ({
+    ...datum,
+    data: datum.data.map(bucket =>
+      ({ x: bucket.bucket, y: bucket.value })
+    )
+  }));
+
+  console.log("prepareData", processed);
+  return processed;
+};
+
+const graphWrapper = (data) =>
+  <div style={{minHeight: "300px", height: "300px"}}>
+    <MyResponsiveLine data={prepareData([data])} yAxisLabel={`${data.type} for ${data.id}`} />
+  </div>;
 
 export default ({ type, metricName, data, handleRemovingChart }) => {
   return (
@@ -12,12 +369,7 @@ export default ({ type, metricName, data, handleRemovingChart }) => {
           <i className="fa fa-times" aria-hidden="true"></i>
         </span>
         <div className="card-body">
-          <h1>{!!data ? "THIS IS TIME SERIES DATA: " + JSON.stringify(data) : "Loading Timeseries..."}</h1>
-          <small>
-            <strong>{type}</strong>
-            {" chart for "}
-            <strong>{metricName}</strong>
-          </small>
+          <div>{data && graphWrapper({ id: metricName, color: "hsl(72, 70%, 50%)", type, data })}</div>
         </div>
       </div>
     </div>

--- a/src/timeseries-metric-chart.js
+++ b/src/timeseries-metric-chart.js
@@ -1,297 +1,37 @@
 import React from 'react';
 import { ResponsiveLine } from '@nivo/line'
 
-const METRIC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f";
-const TIME_DISPLAY_FORMAT = "%H:%M:%S";
+function firstIndexOfDisimilarity(str1, str2) {
+  let idx = 0
 
-const data = [
-    {
-      "id": "japan",
-      "color": "hsl(112, 70%, 50%)",
-      "data": [
-        {
-          "x": "plane",
-          "y": 49
-        },
-        {
-          "x": "helicopter",
-          "y": 252
-        },
-        {
-          "x": "boat",
-          "y": 244
-        },
-        {
-          "x": "train",
-          "y": 231
-        },
-        {
-          "x": "subway",
-          "y": 243
-        },
-        {
-          "x": "bus",
-          "y": 151
-        },
-        {
-          "x": "car",
-          "y": 112
-        },
-        {
-          "x": "moto",
-          "y": 264
-        },
-        {
-          "x": "bicycle",
-          "y": 170
-        },
-        {
-          "x": "horse",
-          "y": 99
-        },
-        {
-          "x": "skateboard",
-          "y": 299
-        },
-        {
-          "x": "others",
-          "y": 219
-        }
-      ]
-    },
-    {
-      "id": "france",
-      "color": "hsl(145, 70%, 50%)",
-      "data": [
-        {
-          "x": "plane",
-          "y": 86
-        },
-        {
-          "x": "helicopter",
-          "y": 171
-        },
-        {
-          "x": "boat",
-          "y": 29
-        },
-        {
-          "x": "train",
-          "y": 171
-        },
-        {
-          "x": "subway",
-          "y": 37
-        },
-        {
-          "x": "bus",
-          "y": 256
-        },
-        {
-          "x": "car",
-          "y": 3
-        },
-        {
-          "x": "moto",
-          "y": 295
-        },
-        {
-          "x": "bicycle",
-          "y": 252
-        },
-        {
-          "x": "horse",
-          "y": 235
-        },
-        {
-          "x": "skateboard",
-          "y": 256
-        },
-        {
-          "x": "others",
-          "y": 69
-        }
-      ]
-    },
-    {
-      "id": "us",
-      "color": "hsl(345, 70%, 50%)",
-      "data": [
-        {
-          "x": "plane",
-          "y": 225
-        },
-        {
-          "x": "helicopter",
-          "y": 23
-        },
-        {
-          "x": "boat",
-          "y": 0
-        },
-        {
-          "x": "train",
-          "y": 216
-        },
-        {
-          "x": "subway",
-          "y": 186
-        },
-        {
-          "x": "bus",
-          "y": 104
-        },
-        {
-          "x": "car",
-          "y": 145
-        },
-        {
-          "x": "moto",
-          "y": 282
-        },
-        {
-          "x": "bicycle",
-          "y": 272
-        },
-        {
-          "x": "horse",
-          "y": 95
-        },
-        {
-          "x": "skateboard",
-          "y": 101
-        },
-        {
-          "x": "others",
-          "y": 67
-        }
-      ]
-    },
-    {
-      "id": "germany",
-      "color": "hsl(293, 70%, 50%)",
-      "data": [
-        {
-          "x": "plane",
-          "y": 245
-        },
-        {
-          "x": "helicopter",
-          "y": 251
-        },
-        {
-          "x": "boat",
-          "y": 55
-        },
-        {
-          "x": "train",
-          "y": 118
-        },
-        {
-          "x": "subway",
-          "y": 23
-        },
-        {
-          "x": "bus",
-          "y": 167
-        },
-        {
-          "x": "car",
-          "y": 47
-        },
-        {
-          "x": "moto",
-          "y": 23
-        },
-        {
-          "x": "bicycle",
-          "y": 118
-        },
-        {
-          "x": "horse",
-          "y": 50
-        },
-        {
-          "x": "skateboard",
-          "y": 100
-        },
-        {
-          "x": "others",
-          "y": 131
-        }
-      ]
-    },
-    {
-      "id": "norway",
-      "color": "hsl(72, 70%, 50%)",
-      "data": [
-        {
-          "x": "plane",
-          "y": 280
-        },
-        {
-          "x": "helicopter",
-          "y": 50
-        },
-        {
-          "x": "boat",
-          "y": 48
-        },
-        {
-          "x": "train",
-          "y": 207
-        },
-        {
-          "x": "subway",
-          "y": 200
-        },
-        {
-          "x": "bus",
-          "y": 209
-        },
-        {
-          "x": "car",
-          "y": 284
-        },
-        {
-          "x": "moto",
-          "y": 218
-        },
-        {
-          "x": "bicycle",
-          "y": 32
-        },
-        {
-          "x": "horse",
-          "y": 260
-        },
-        {
-          "x": "skateboard",
-          "y": 276
-        },
-        {
-          "x": "others",
-          "y": 298
-        }
-      ]
-    }
-  ];
+  while (idx < str1.length && idx < str2.length) {
+    if (str1[idx] !== str2[idx]) break;
+    idx++;
+  }
 
-const MyResponsiveLine = ({ data, yAxisLabel }) => (
+  if (idx == Math.min(str1.length, str2.length)) {
+    return false;
+  }
+
+  return idx;
+}
+
+const MyResponsiveLine = ({ data, yAxisLabel, xFormatter }) => (
   <ResponsiveLine
     data={data}
-    margin={{ top: 50, right: 110, bottom: 50, left: 60 }}
+    margin={{ top: 10, right: 30, bottom: 50, left: 50 }}
     xScale={{ type: 'point' }}
     yScale={{ type: 'linear', stacked: true, min: 'auto', max: 'auto' }}
     axisTop={null}
     axisRight={null}
     axisBottom={{
       orient: 'bottom',
+      format: xFormatter,
       tickSize: 5,
       tickPadding: 5,
-      tickRotation: 0,
+      tickRotation: 270,
       legend: 'Time/Bucket',
-      legendOffset: 36,
+      legendOffset: 26,
       legendPosition: 'middle'
     }}
     axisLeft={{
@@ -311,32 +51,6 @@ const MyResponsiveLine = ({ data, yAxisLabel }) => (
     pointLabel="y"
     pointLabelYOffset={-12}
     useMesh={true}
-    _legends={[
-      {
-        anchor: 'bottom-right',
-        direction: 'column',
-        justify: false,
-        translateX: 100,
-        translateY: 0,
-        itemsSpacing: 0,
-        itemDirection: 'left-to-right',
-        itemWidth: 80,
-        itemHeight: 20,
-        itemOpacity: 0.75,
-        symbolSize: 12,
-        symbolShape: 'circle',
-        symbolBorderColor: 'rgba(0, 0, 0, .5)',
-        effects: [
-          {
-            on: 'hover',
-            style: {
-              itemBackground: 'rgba(0, 0, 0, .03)',
-              itemOpacity: 1
-            }
-          }
-        ]
-      }
-    ]}
   />
 );
 
@@ -352,10 +66,18 @@ const prepareData = (ndata) => {
   return processed;
 };
 
-const graphWrapper = (data) =>
-  <div style={{minHeight: "300px", height: "300px"}}>
-    <MyResponsiveLine data={prepareData([data])} yAxisLabel={`${data.type} for ${data.id}`} />
-  </div>;
+const graphWrapper = (data) => {
+
+  let lastIdx = firstIndexOfDisimilarity(data.data[0].bucket, data.data[data.data.length - 1].bucket);
+
+  if (lastIdx === false) lastIdx = data.data[0].bucket.length - 6;
+
+  return (
+    <div style={{minHeight: "300px", height: "300px"}}>
+      <MyResponsiveLine data={prepareData([data])} yAxisLabel={`${data.type} for ${data.id}`} xFormatter={(val) => val.slice(lastIdx)} />
+    </div>
+  );
+};
 
 export default ({ type, metricName, data, handleRemovingChart }) => {
   return (
@@ -370,6 +92,11 @@ export default ({ type, metricName, data, handleRemovingChart }) => {
         </span>
         <div className="card-body">
           <div>{data && graphWrapper({ id: metricName, color: "hsl(72, 70%, 50%)", type, data })}</div>
+          <small>
+            <strong>{type}</strong>
+            {" graph for "}
+            <strong>{metricName}</strong>
+          </small>
         </div>
       </div>
     </div>

--- a/src/timeseries-metric-chart.js
+++ b/src/timeseries-metric-chart.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default ({ type, metricName, data, handleRemovingChart }) => {
+  return (
+    <div className="col-md-4 mb-4">
+      <div className="card">
+        <span
+          style={{textAlign: "right", cursor: "pointer"}}
+          className="pt-2 pr-2"
+          onClick={() => handleRemovingChart()}
+        >
+          <i className="fa fa-times" aria-hidden="true"></i>
+        </span>
+        <div className="card-body">
+          <h1>{!!data ? "THIS IS TIME SERIES DATA" : "Loading Timeseries..."}</h1>
+          <small>
+            <strong>{type}</strong>
+            {" chart for "}
+            <strong>{metricName}</strong>
+          </small>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Also in this PR
- fixed up the general styling of the main page
- refreshes all charts when dates are changed
- loads metric_name from query param (uses `q=...`)
- fixed oopsies about timezones when loading dates from query params


### This is what the aggregates chart looks like:

![Screen Shot 2020-04-11 at 6 20 38 PM](https://user-images.githubusercontent.com/11997716/79056151-5466a700-7c21-11ea-8a09-285f7d34c8b3.png)


### And the main page as a whole

![Screen Shot 2020-04-11 at 6 23 18 PM](https://user-images.githubusercontent.com/11997716/79056175-8aa42680-7c21-11ea-9cea-5c15fc6a39b8.png)
